### PR TITLE
Fix properties binding failure

### DIFF
--- a/src/main/java/com/icthh/xm/gate/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/gate/config/ApplicationProperties.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "application")
 public class ApplicationProperties {
 
     private final Retry retry = new Retry();


### PR DESCRIPTION
It was unable to override 'application.hosts' property with external property (APPLICATION_HOSTS=...) while '@ConfigurationProperties.ignoreUnknownFields' is false.