### PR TITLE
Add swagger v3 definition to /swagger-resources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=gate
 profile=dev
-version=2.1.9
+version=2.1.10
 
 # Build properties
 node_version=12.13.0


### PR DESCRIPTION
Adding correct swagger version and path to /swagger-resources

was
```
[ {
  "name" : "default",
  "url" : "/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/v2/api-docs"
}, {
  "name" : "config",
  "url" : "/config/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/config/v2/api-docs"
}, {
  "name" : "customer",
  "url" : "/customer/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/customer/v2/api-docs"
}, {
  "name" : "uaa",
  "url" : "/uaa/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/uaa/v2/api-docs"
} ]
```

will be
```
[ {
  "name" : "default",
  "url" : "v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "v2/api-docs"
}, {
  "name" : "config",
  "url" : "/config/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/config/v2/api-docs"
}, {
  "name" : "customer",
  "url" : "/customer/v3/api-docs",
  "swaggerVersion" : "3.0",
  "location" : "/customer/v3/api-docs"
}, {
  "name" : "uaa",
  "url" : "/uaa/v2/api-docs",
  "swaggerVersion" : "2.0",
  "location" : "/uaa/v2/api-docs"
} ]
```

based on tags -> swagger (v2 will be default)
```
  cloud:
    consul:
      discovery:
        tags:
          - profile=${spring.profiles.active}
          - version=#project.version#
          - git-version=${git.commit.id.describe:}
          - git-commit=${git.commit.id.abbrev:}
          - git-branch=${git.branch:}
          - context-path=${server.servlet.context-path:}
          - swagger=v3
```