### PR TITLE
remove duplicated plugin apply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id "jacoco"
     id "org.springframework.boot"
     id "com.google.cloud.tools.jib"
-    id "com.gorylenko.gradle-git-properties"
     id "net.ltgt.apt-eclipse"
     id "net.ltgt.apt-idea"
     id "net.ltgt.apt"


### PR DESCRIPTION
this fix relates to this problem: https://jenkins.local.jevera.software/job/icthothouse/job/arm/job/xm-gate/18/console

```
* What went wrong:
A problem occurred configuring root project 'xm-gate'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.ajoberstar.grgit:grgit-core:3.1.1.
     Required by:
         project : > com.gorylenko.gradle-git-properties:com.gorylenko.gradle-git-properties.gradle.plugin:2.2.0 > gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.0
      > Could not resolve org.ajoberstar.grgit:grgit-core:3.1.1.
         > Could not get resource 'https://repo.spring.io/plugins-release/org/ajoberstar/grgit/grgit-core/3.1.1/grgit-core-3.1.1.pom'.
            > Could not GET 'https://repo.spring.io/plugins-release/org/ajoberstar/grgit/grgit-core/3.1.1/grgit-core-3.1.1.pom'. Received status code 401 from server: 
```