### PR TITLE
covered consul request with cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ dependencies {
     implementation "org.bitbucket.b_c:jose4j:${bitbucket_version}"
     implementation "com.google.protobuf:protobuf-java:${google_protobuf_version}"
     implementation 'org.apache.httpcomponents.client5:httpclient5'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     implementation "com.icthh.xm.commons:xm-commons-tenant-endpoint:${xm_commons_version}"
     implementation "com.icthh.xm.commons:xm-commons-idp:${xm_commons_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=gate
 profile=dev
-version=3.0.24
+version=3.0.25
 
 # Dependency versions
 spring_boot_version=4.0.1

--- a/src/main/java/com/icthh/xm/gate/config/properties/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/gate/config/properties/ApplicationProperties.java
@@ -63,10 +63,18 @@ public class ApplicationProperties {
     public static class Gateway {
         private Set<String> excludedServices = Set.of("consul", "gate");
         private List<AuthRequestMatcherRule> authRequestMatcherRules = List.of();
+        private final ServicesCache servicesCache = new ServicesCache();
 
         public List<AuthRequestMatcherRule> getAuthRequestMatcherRules() {
             return Collections.unmodifiableList(this.authRequestMatcherRules);
         }
+    }
+
+    @Getter
+    @Setter
+    public static class ServicesCache {
+        private boolean enabled = false;
+        private long ttlSeconds = 300;
     }
 
     @Getter

--- a/src/main/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManager.java
+++ b/src/main/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManager.java
@@ -4,8 +4,8 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.icthh.xm.gate.config.properties.ApplicationProperties;
 import com.icthh.xm.gate.config.properties.ApplicationProperties.AuthRequestMatcherRule;
+import com.icthh.xm.gate.config.properties.ApplicationProperties.ServicesCache;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
@@ -32,20 +32,24 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class AccessControlAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
 
     private static final AuthorizationDecision DENY = new AuthorizationDecision(false);
     private static final AuthorizationDecision ALLOW = new AuthorizationDecision(true);
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
-    private static final String SERVICES_CACHE_PREFIX = "REGISTERED_SERVICE@";
 
     private final DiscoveryClient discoveryClient;
     private final ApplicationProperties appProperties;
+    private final Cache<String, Boolean> registeredServicesCache;
 
-    private final Cache<String, Set<String>> registeredServicesCache = Caffeine.newBuilder()
-        .expireAfterWrite(5, TimeUnit.MINUTES)
-        .build();
+    public AccessControlAuthorizationManager(DiscoveryClient discoveryClient, ApplicationProperties appProperties) {
+        this.discoveryClient = discoveryClient;
+        this.appProperties = appProperties;
+        ServicesCache cacheConfig = appProperties.getGateway().getServicesCache();
+        this.registeredServicesCache = cacheConfig.isEnabled()
+            ? Caffeine.newBuilder().expireAfterWrite(cacheConfig.getTtlSeconds(), TimeUnit.SECONDS).build()
+            : null;
+    }
 
     @Override
     public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication,
@@ -114,12 +118,19 @@ public class AccessControlAuthorizationManager implements AuthorizationManager<R
     }
 
     private boolean isRegisteredService(String serviceName) {
-        Set<String> services = registeredServicesCache.get(SERVICES_CACHE_PREFIX + serviceName, _ ->
-            discoveryClient.getServices().stream()
-                .map(String::toLowerCase)
-                .collect(Collectors.toSet())
+        String lowerCaseName = serviceName.toLowerCase();
+        if (registeredServicesCache == null) {
+            return fetchServicesLowerCase().contains(lowerCaseName);
+        }
+        return Boolean.TRUE.equals(
+            registeredServicesCache.get(lowerCaseName, key -> fetchServicesLowerCase().contains(key))
         );
-        return services != null && services.contains(serviceName.toLowerCase());
+    }
+
+    private Set<String> fetchServicesLowerCase() {
+        return discoveryClient.getServices().stream()
+            .map(String::toLowerCase)
+            .collect(Collectors.toSet());
     }
 
     private String getRequestUri(RequestAuthorizationContext ctx) {

--- a/src/main/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManager.java
+++ b/src/main/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManager.java
@@ -1,5 +1,7 @@
 package com.icthh.xm.gate.gateway.accesscontrol;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.icthh.xm.gate.config.properties.ApplicationProperties;
 import com.icthh.xm.gate.config.properties.ApplicationProperties.AuthRequestMatcherRule;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +22,8 @@ import org.springframework.util.AntPathMatcher;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -34,9 +38,14 @@ public class AccessControlAuthorizationManager implements AuthorizationManager<R
     private static final AuthorizationDecision DENY = new AuthorizationDecision(false);
     private static final AuthorizationDecision ALLOW = new AuthorizationDecision(true);
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+    private static final String SERVICES_CACHE_PREFIX = "REGISTERED_SERVICE@";
 
     private final DiscoveryClient discoveryClient;
     private final ApplicationProperties appProperties;
+
+    private final Cache<String, Set<String>> registeredServicesCache = Caffeine.newBuilder()
+        .expireAfterWrite(5, TimeUnit.MINUTES)
+        .build();
 
     @Override
     public @Nullable AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication,
@@ -105,9 +114,12 @@ public class AccessControlAuthorizationManager implements AuthorizationManager<R
     }
 
     private boolean isRegisteredService(String serviceName) {
-        return discoveryClient.getServices()
-            .stream()
-            .anyMatch(s -> s.equalsIgnoreCase(serviceName));
+        Set<String> services = registeredServicesCache.get(SERVICES_CACHE_PREFIX + serviceName, _ ->
+            discoveryClient.getServices().stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet())
+        );
+        return services != null && services.contains(serviceName.toLowerCase());
     }
 
     private String getRequestUri(RequestAuthorizationContext ctx) {

--- a/src/test/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManagerUnitTest.java
+++ b/src/test/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManagerUnitTest.java
@@ -45,9 +45,13 @@ class AccessControlAuthorizationManagerUnitTest {
 
     @BeforeEach
     void setUp() {
+        var servicesCache = new ApplicationProperties.ServicesCache();
+        servicesCache.setEnabled(true);
+
+        when(appProperties.getGateway()).thenReturn(gateway);
+        when(gateway.getServicesCache()).thenReturn(servicesCache); // disabled by default
         manager = new AccessControlAuthorizationManager(discoveryClient, appProperties);
         when(ctx.getRequest()).thenReturn(servletRequest);
-        when(appProperties.getGateway()).thenReturn(gateway);
     }
 
     @Test

--- a/src/test/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManagerUnitTest.java
+++ b/src/test/java/com/icthh/xm/gate/gateway/accesscontrol/AccessControlAuthorizationManagerUnitTest.java
@@ -22,6 +22,8 @@ import static java.util.Arrays.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -231,6 +233,38 @@ class AccessControlAuthorizationManagerUnitTest {
         when(discoveryClient.getServices()).thenReturn(List.of());
 
         assertTrue(isGranted(manager.authorize(authenticated(), ctx)));
+    }
+
+    @Test
+    void consul_is_called_only_once_for_repeated_requests_within_cache_ttl() {
+        when(servletRequest.getRequestURI()).thenReturn("/my-service/api/data");
+        when(gateway.getAuthRequestMatcherRules()).thenReturn(List.of());
+        when(discoveryClient.getServices()).thenReturn(List.of("my-service"));
+
+        manager.authorize(unauthenticated(), ctx);
+        manager.authorize(unauthenticated(), ctx);
+        manager.authorize(unauthenticated(), ctx);
+
+        verify(discoveryClient, times(1)).getServices();
+    }
+
+    @Test
+    void single_consul_call_covers_multiple_different_service_names() {
+        when(gateway.getAuthRequestMatcherRules()).thenReturn(List.of());
+        when(discoveryClient.getServices()).thenReturn(List.of("service-a", "service-b"));
+        when(servletRequest.getRequestURI()).thenReturn("/service-a/api/data");
+
+        HttpServletRequest requestB = mock(HttpServletRequest.class);
+        RequestAuthorizationContext ctxB = mock(RequestAuthorizationContext.class);
+        when(ctxB.getRequest()).thenReturn(requestB);
+        when(requestB.getRequestURI()).thenReturn("/service-b/api/data");
+
+        assertTrue(isGranted(manager.authorize(unauthenticated(), ctx)));
+        assertTrue(isGranted(manager.authorize(unauthenticated(), ctxB)));
+        assertTrue(isGranted(manager.authorize(unauthenticated(), ctx)));
+        assertTrue(isGranted(manager.authorize(unauthenticated(), ctxB)));
+
+        verify(discoveryClient, times(2)).getServices();
     }
 
     private static boolean isGranted(AuthorizationResult result) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version Update**
  * Released version **3.0.25**.

* **New Features**
  * Added an **optional service-discovery cache** for access control registered-service checks, configurable via gateway settings (**enabled** and **TTL**).

* **Performance Improvements**
  * Reduced repeated service-discovery calls for repeated authorization checks within the cache TTL.
  * Improved gateway responsiveness for access control operations by avoiding redundant lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->