### PR TITLE
Add junit-platform-launcher so tests run on Gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,9 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-webmvc-test"
     testImplementation "org.projectlombok:lombok:${lombok_version}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombok_version}"
+    // Gradle 9 no longer puts the JUnit Platform launcher on the test runtime
+    // classpath implicitly, so it has to be declared explicitly.
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 spotbugs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=gate
 profile=dev
 
-version=3.0.35
+version=3.0.36
 
 
 # Dependency versions


### PR DESCRIPTION
## Problem

`./gradlew clean test` fails before executing a single test:

```
Execution failed for task ':test'.
> Test process encountered an unexpected problem.
   > Could not start Gradle Test Executor 1: Failed to load JUnit Platform.
     Please ensure that all JUnit Platform dependencies are available on the
     test's runtime classpath, including the JUnit Platform launcher.
```

Gradle 9 no longer puts the JUnit Platform launcher on the test runtime classpath implicitly. Neither `spring-boot-starter-test` nor any other declared dependency brings it in transitively here, so **all 26 test classes were silently skipped**.

This was found while verifying the Java 25 migration: the repository reported a clean build while running zero tests.

## Fix

Declare the launcher explicitly:

```gradle
testRuntimeOnly "org.junit.platform:junit-platform-launcher"
```

## Verification

`./gradlew clean test` on Eclipse Temurin 25.0.1, Gradle 9.2.1:

| | before | after |
|---|---|---|
| Result | BUILD FAILED | BUILD SUCCESSFUL |
| Tests executed | 0 | **129** |
| Failures | — | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Gradle 9 test execution by adding the required JUnit Platform runtime support.

* **Release**
  * Updated the project version to 3.0.36.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->