### PR TITLE
Update xm-commons to 5.0.36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=gate
 profile=dev
 
-version=3.0.36
+version=3.0.37
 
 
 # Dependency versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ spring_boot_version=4.1.0
 spring_cloud_version=2025.1.2
 spring_dependency_management_version=1.1.7
 
-xm_commons_version=5.0.35
+xm_commons_version=5.0.36
 
 springdoc_version=3.0.3
 lombok_version=1.18.46


### PR DESCRIPTION
Bumps `xm_commons_version` from **5.0.35** to **5.0.36**.

## Verification

`./gradlew clean test` on Eclipse Temurin 25.0.1, Gradle 9.2.1:

| | |
|---|---|
| Result | BUILD SUCCESSFUL |
| Tests | **129** |
| Failures | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project to version 3.0.37.
  * Updated the xm_commons dependency to version 5.0.36.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->